### PR TITLE
config/application.rbの編集してrails gコマンド実行時に不要なファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,11 @@ module FreemarketSample39i
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module FreemarketSample39i
       g.javascripts false
       g.helper false
       g.test_framework false
+      g.template_engine :haml
     end
   end
 end


### PR DESCRIPTION
# What
config/application.rbにrails gコマンド実行時に不要なファイルが生成されないようにする。

# Why
不要なファイルが生成されないようにあらかじめ設定しておくことで、後に無駄な作業をしなくてすむようにするため。