### PR TITLE
rails-controller-testingのインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'factory_girl_rails', "~> 4.4.1"
   gem 'faker'
+  gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3.5'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -240,6 +244,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.1)
+  rails-controller-testing
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   spring


### PR DESCRIPTION
# what
rails-controller-testingのインストール

# why
rspec-rails だけで使えていた assignsメソッド がRails5からrails-controller-testingがないと使えなくなったから。