### PR TITLE
GemfileでRubyバージョンを指定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+ruby "2.5.1"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.7', '>= 5.0.7.1'


### PR DESCRIPTION
# What
GemfileでRubyバージョンを2.5.1に指定する。

# Why
GemfileにRubyのバージョンを明記し、チームメンバー間でRubyのバージョンを揃えることで、予期せぬエラーを防ぐため。