### PR TITLE
font-awesome-sassを使えるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
 gem 'erb2haml'
-gem 'font-awesome-rails'
+gem 'font-awesome-sass', '~> 5.8.1'
 gem 'haml-rails'
 gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,8 +89,8 @@ GEM
     faker (1.9.3)
       i18n (>= 0.7)
     ffi (1.10.0)
-    font-awesome-rails (4.7.0.4)
-      railties (>= 3.2, < 6.0)
+    font-awesome-sass (5.8.1)
+      sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -212,6 +212,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     sexp_processor (4.11.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -268,7 +271,7 @@ DEPENDENCIES
   erb2haml
   factory_girl_rails (~> 4.4.1)
   faker
-  font-awesome-rails
+  font-awesome-sass (~> 5.8.1)
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import "font-awesome";
+@import "font-awesome-sprockets";
 @import "./color";
 @import "./clearfix";


### PR DESCRIPTION
# What
font-awesome-railsの代わりにfont-awesome-sassを導入する。

# Why
Fontawesome 5系から使えるようになったsolidやregularなどのスタイルを使えるようにするため。