### PR TITLE
赤い丸型の「出品」ボタンのマークアップ

### DIFF
--- a/app/assets/stylesheets/_sell-btn.scss
+++ b/app/assets/stylesheets/_sell-btn.scss
@@ -1,0 +1,23 @@
+@import "color";
+
+.sell-btn {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  z-index: 1000;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: $cinnabar;
+  text-align: center;
+  &__link {
+    color: $white;
+    font-size: 22px;
+  }
+  &__text {
+    margin: 27px 0 0;
+  }
+  &__icon {
+    font-size: 60px;
+  }
+}

--- a/app/assets/stylesheets/_sell-btn.scss
+++ b/app/assets/stylesheets/_sell-btn.scss
@@ -1,16 +1,16 @@
 @import "color";
 
 .sell-btn {
-  position: fixed;
-  bottom: 32px;
-  right: 32px;
-  z-index: 1000;
-  width: 160px;
-  height: 160px;
-  border-radius: 50%;
-  background: $cinnabar;
-  text-align: center;
   &__link {
+    position: fixed;
+    bottom: 32px;
+    right: 32px;
+    z-index: 1000;
+    background: $cinnabar;
+    width: 160px;
+    height: 160px;
+    border-radius: 50%;
+    text-align: center;
     color: $white;
     font-size: 22px;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import "./pickup";
 @import "./product-box";
 @import "./products-box";
+@import "./sell-btn";
 
 
 // header

--- a/app/views/samples/sample.html.haml
+++ b/app/views/samples/sample.html.haml
@@ -107,4 +107,5 @@
       %figure.app-banner-right__figure
         = image_tag "download_content_pc.png", class: "app-banner-right__image"
 
+= render 'shared/sell-btn'
 = render 'shared/footer'

--- a/app/views/shared/_sell-btn.html.haml
+++ b/app/views/shared/_sell-btn.html.haml
@@ -1,0 +1,4 @@
+.sell-btn
+  = link_to root_path, class: "sell-btn__link" do
+    .sell-btn__text 出品
+    = icon("fas", "camera", class: "sell-btn__icon")


### PR DESCRIPTION
# What
トップページ右下に表示される赤い丸型の出品ボタンのマークアップ。
まだ出品ページが完成してないので、リンクはroot_pathを指定してある。
また、このボタンは他のページでも使われているので部分テンプレート化した。

https://gyazo.com/cba77b3cb502603b962402478f74c2c5

# Why
ボタン１つですぐに出品画面に飛べるようにするため。

本家メルカリと見た目を同じにするため。