### PR TITLE
本番環境で画像の表示が崩れる問題を修正

### DIFF
--- a/app/views/samples/sample.html.haml
+++ b/app/views/samples/sample.html.haml
@@ -124,7 +124,7 @@
               = image_tag "app-store.svg", class: "app-banner-btn__image", width: "133", height: "40"
           %li.app-banner-btn__list
             = link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", class: "app-banner-btn__link", target: "_blank" do
-              = image_tag "google-play", class: "app-banner-btn__image", width: "133", height: "40"
+              = image_tag "google-play.svg", class: "app-banner-btn__image", width: "133", height: "40"
     .app-banner-right
       %figure.app-banner-right__figure
         = image_tag "download_content_pc.png", class: "app-banner-right__image"


### PR DESCRIPTION
# what
app-bannerにある以下の部分で、"google-play"となっているところを、"google-play.svg"に変更する。

= image_tag "google-play", class: "app-banner-btn__image", width: "133", height: "40"

# why
この部分が本番環境ではきちんと表示されていないから。

https://gyazo.com/ac9c702c16167e28d15234eb1bdb083a
