### PR TITLE
 "app-banner"ブロックを部分テンプレート化する

### DIFF
--- a/app/assets/stylesheets/app-banner/_app-banner-btn.scss
+++ b/app/assets/stylesheets/app-banner/_app-banner-btn.scss
@@ -22,5 +22,7 @@
   }
   &__image {
     vertical-align: middle;
+    width: 133px;
+    height: 40px;
   }
 }

--- a/app/assets/stylesheets/app-banner/_app-banner-icon.scss
+++ b/app/assets/stylesheets/app-banner/_app-banner-icon.scss
@@ -1,3 +1,6 @@
 .app-banner-icon {
   float: left;
+  &__image {
+    width: 68px;
+  }
 }

--- a/app/views/samples/sample.html.haml
+++ b/app/views/samples/sample.html.haml
@@ -108,26 +108,5 @@
       =link_to root_path, class: "products-box__view-all-link" do
         すべての商品を見る
 
-%aside.app-banner
-  .app-banner__wrapper
-    .app-banner-left
-      .app-banner-body
-        %h2.app-banner-body__head スマホでかんたんフリマアプリ
-        %p.app-banner-body__text 今すぐ無料ダウンロード！
-      .app-banner-icon-btn
-        .app-banner-icon
-          %figure.app-banner-icon__figure
-            = image_tag "mercari_icon.png", class: "app-banner-icon__image", width: "68px";
-        %ul.app-banner-btn
-          %li.app-banner-btn__list
-            = link_to "https://itunes.apple.com/jp/app/id667861049?l=ja&mt=8", class: "app-banner-btn__link", target: "_blank" do
-              = image_tag "app-store.svg", class: "app-banner-btn__image", width: "133", height: "40"
-          %li.app-banner-btn__list
-            = link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", class: "app-banner-btn__link", target: "_blank" do
-              = image_tag "google-play.svg", class: "app-banner-btn__image", width: "133", height: "40"
-    .app-banner-right
-      %figure.app-banner-right__figure
-        = image_tag "download_content_pc.png", class: "app-banner-right__image"
-
 = render 'shared/sell-btn'
 = render 'shared/footer'

--- a/app/views/samples/sample.html.haml
+++ b/app/views/samples/sample.html.haml
@@ -108,5 +108,6 @@
       =link_to root_path, class: "products-box__view-all-link" do
         すべての商品を見る
 
+= render 'shared/app-banner'
 = render 'shared/sell-btn'
 = render 'shared/footer'

--- a/app/views/shared/_app-banner.html.haml
+++ b/app/views/shared/_app-banner.html.haml
@@ -1,0 +1,20 @@
+%aside.app-banner
+  .app-banner__wrapper
+    .app-banner-left
+      .app-banner-body
+        %h2.app-banner-body__head スマホでかんたんフリマアプリ
+        %p.app-banner-body__text 今すぐ無料ダウンロード！
+      .app-banner-icon-btn
+        .app-banner-icon
+          %figure.app-banner-icon__figure
+            = image_tag "mercari_icon.png", class: "app-banner-icon__image", width: "68px";
+        %ul.app-banner-btn
+          %li.app-banner-btn__list
+            = link_to "https://itunes.apple.com/jp/app/id667861049?l=ja&mt=8", class: "app-banner-btn__link", target: "_blank" do
+              = image_tag "app-store.svg", class: "app-banner-btn__image", width: "133", height: "40"
+          %li.app-banner-btn__list
+            = link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", class: "app-banner-btn__link", target: "_blank" do
+              = image_tag "google-play.svg", class: "app-banner-btn__image", width: "133", height: "40"
+    .app-banner-right
+      %figure.app-banner-right__figure
+        = image_tag "download_content_pc.png", class: "app-banner-right__image"

--- a/app/views/shared/_app-banner.html.haml
+++ b/app/views/shared/_app-banner.html.haml
@@ -7,14 +7,14 @@
       .app-banner-icon-btn
         .app-banner-icon
           %figure.app-banner-icon__figure
-            = image_tag "mercari_icon.png", class: "app-banner-icon__image", width: "68px";
+            = image_tag "mercari_icon.png", class: "app-banner-icon__image"
         %ul.app-banner-btn
           %li.app-banner-btn__list
             = link_to "https://itunes.apple.com/jp/app/id667861049?l=ja&mt=8", class: "app-banner-btn__link", target: "_blank" do
-              = image_tag "app-store.svg", class: "app-banner-btn__image", width: "133", height: "40"
+              = image_tag "app-store.svg", class: "app-banner-btn__image"
           %li.app-banner-btn__list
             = link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", class: "app-banner-btn__link", target: "_blank" do
-              = image_tag "google-play.svg", class: "app-banner-btn__image", width: "133", height: "40"
+              = image_tag "google-play.svg", class: "app-banner-btn__image"
     .app-banner-right
       %figure.app-banner-right__figure
         = image_tag "download_content_pc.png", class: "app-banner-right__image"


### PR DESCRIPTION
# What
"app-banner"という名前のBlockを部分テンプレートとして切り出す。

https://gyazo.com/7b9ebdf569cddeecadc4c2d01c137b71

# Why
複数の箇所で使われていることに気がついたので、部分テンプレート化することで、再利用しやすくするため。